### PR TITLE
changes to setup environments in intel macs

### DIFF
--- a/setup/macintosh_requirements_pytorch_cpu.txt
+++ b/setup/macintosh_requirements_pytorch_cpu.txt
@@ -1,0 +1,10 @@
+--extra-index-url https://download.pytorch.org/whl/cpu  # required for linux since otherwise the default is the GPU version
+#torch==2.0.0+cpu  # for Windows and Mac this installs the CPU-only version (no GPU)
+torch==2.0.0
+#torchvision==0.15.1+cpu  # needed to the pytorch-tensorboard tutorial, for downloading fashion-mnist
+torchvision==0.15.1 
+tensorboard==2.12.3
+matplotlib==3.7.1
+numpy==1.24.3
+ipykernel==6.22.0  # needed to run jupyter notebooks 
+nbconvert==7.3.1  # needed for converting ipynb to other formats such as python, html and pdf 

--- a/setup/setup.py
+++ b/setup/setup.py
@@ -104,7 +104,12 @@ def install_packages(venv_path:str, requirements_path:str, platform:str, shell:s
     import subprocess
     import sys
     print(f'{venv_path} - Installing packages...')
-    if (platform == 'Linux') | (platform == 'Darwin'):
+    if (platform == 'Linux'):
+        subprocess.run(f'{venv_path}/bin/pip install -r {requirements_path}', shell=True)
+    elif (platform == 'Darwin'):
+        directory, filename = os.path.split(requirements_path)
+        new_filename = 'macintosh_' + filename
+        requirements_path = os.path.join(directory, new_filename)
         subprocess.run(f'{venv_path}/bin/pip install -r {requirements_path}', shell=True)
     elif platform == 'Windows':
         subprocess.run(fr'{venv_path}\Scripts\pip install -r {requirements_path}', shell=True)


### PR DESCRIPTION
closes #7 

1. Added 'macintosh_requirements_pytorch_cpu.txt' which contains macintosh-friendly package names.
2. Updates in 'setup.py' to install this file instead of the default one in case the platform is 'Darwin'.

Note: I am unsure of the impact of this change on Apple Silicon Macbooks for pytorch environment setup.